### PR TITLE
Removing Researcher

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -10,9 +10,6 @@ akithecatearedmerc:
 likerofjazz: 
   name: M0r1
   url: https://www.youtube.com/watch?v=p3oUHn1gOAY&list=RDp3oUHn1gOAY&start_radio=1
-darkfly0213:
-  name: darkfly0213
-  url: https://github.com/darkfly02131
 izzyboop:
   name: IzzyBoop
   url: https://github.com/IzzyBoop

--- a/_data/researchers.yml
+++ b/_data/researchers.yml
@@ -10,9 +10,6 @@ akithecatearedmerc:
 likerofjazz: 
   name: M0r1
   url: https://www.youtube.com/watch?v=p3oUHn1gOAY&list=RDp3oUHn1gOAY&start_radio=1
-darkfly0213:
-  name: darkfly0213
-  url: https://github.com/darkfly02131
 izzyboop:
   name: IzzyBoop
   url: https://github.com/IzzyBoop

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -39,4 +39,4 @@ A middle-school student, currently working with and supporting DeTraced by parti
 "just a teammate"
 
 # Former Researchers
-- darkfly0213
+- [darkfly0213](https://github.com/darkfly02131) (June 2025 - September 2025)

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -25,9 +25,6 @@ A girl who just happens to slip into cyber security and some how is doing fine w
 ### Slavetomints
 A student and researcher with DeTraced Security, where she focuses on Cyber Threat Intelligence. A Ruby enthusiast, she enjoys building small tools that connect her programming interests with real-life applications. She shares her learning journey on her blog so she can see how far she has come since the beginning.
 
-### darkfly0213
-A graduate student majoring in Cybersecurity. I'm someone who is always eager to learn. I like hololive productions, and learning new things. I look forward to the new knowledge and findings that follow the DeTraced Security Research team.
-
 ### M0ri 
 M0ri is a cybersecurity professional and DeTraced researcher, specializing in detection engineering and threat intelligence. M0ri loves teaching others and learning new techniques to detect. 
 
@@ -40,3 +37,6 @@ A middle-school student, currently working with and supporting DeTraced by parti
 
 ### Karmanya03
 "just a teammate"
+
+# Former Researchers
+- darkfly0213

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -39,4 +39,4 @@ A middle-school student, currently working with and supporting DeTraced by parti
 "just a teammate"
 
 # Former Researchers
-- [darkfly0213](https://github.com/darkfly02131) (June 2025 - September 2025)
+- [darkfly0213](https://github.com/darkfly02131) (June 2025–September 2025)


### PR DESCRIPTION
Removed researcher information from `authors.yml` and `researchers.yml`
Removed researcher biography from the About page
Added new section on the About page listing previous researchers

Entire team is requested for review, so we can agree on how to handle this moving forwards