### PR TITLE
[add] Twitter and Bluesky profiles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,8 +28,8 @@ url: "https://detraced.org"
 github:
   username: DeTraced-Security # change to your GitHub username
 
-# twitter:
-#   username:  # change to your Twitter username
+twitter:
+  username:  DetracedSec # change to your Twitter username
 
 social:
   # Change to your full name.

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -7,8 +7,8 @@
   icon: "fa-brands fa-discord"
   url: https://discord.gg/ahecAvxwhh
 
-# - type: twitter
-#   icon: "fa-brands fa-x-twitter"
+- type: twitter
+  icon: "fa-brands fa-x-twitter"
 
 - type: email
   icon: "fas fa-envelope"
@@ -31,9 +31,9 @@
 #   icon: 'fab fa-stack-overflow'
 #   url:  ''                  # Fill with your stackoverflow homepage
 #
-# - type: bluesky
-#   icon: 'fa-brands fa-bluesky'
-#   url: ''                   # Fill with your Bluesky profile link
+- type: bluesky
+  icon: 'fa-brands fa-bluesky'
+  url: 'https://bsky.app/profile/detraced-org.bsky.social'                   # Fill with your Bluesky profile link
 #
 # - type: reddit
 #   icon: 'fa-brands fa-reddit'

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -54,7 +54,12 @@
     {% endunless %}
 
     <!-- the Socials + Email + RSS buttons -->
-    {% for entry in site.data.contact %}
+    {% assign regular_entries = site.data.contact | where_exp: "item", "item.type != 'email' and item.type != 'rss'" %}
+    {% assign email_entries = site.data.contact | where: "type", "email" %}
+    {% assign rss_entries = site.data.contact | where: "type", "rss" %}
+    {% assign ordered_entries = regular_entries | concat: email_entries | concat: rss_entries %}
+    
+    {% for entry in ordered_entries %}
       {%- assign url = null -%}
 
       {% case entry.type %}


### PR DESCRIPTION
This PR adds the Twitter and Bluesky profiles to the sidebar of the blog.

- Twitter profile specified in [_config.yml](https://github.com/DeTraced-Security/detraced-security.github.io/blob/main/_config.yml)
- Bluesky profile specified in [_data/contact.yml](https://github.com/DeTraced-Security/detraced-security.github.io/blob/main/_data/contact.yml)
- Edited [_includes/sidebar.html](https://github.com/DeTraced-Security/detraced-security.github.io/blob/main/_includes/sidebar.html) to reorder icons in order to put everything before email and rss.